### PR TITLE
try to fix UnboundLocalError

### DIFF
--- a/ros/src/twist_controller/dbw_node.py
+++ b/ros/src/twist_controller/dbw_node.py
@@ -94,10 +94,10 @@ class DBWNode(object):
                                                                     self.current_velocity,
                                                                     time_interval)
 
-            if self.dbw_enabled:
-                self.publish(throttle, brake, steering)
-            else:
-                self.controller.reset()
+                if self.dbw_enabled:
+                    self.publish(throttle, brake, steering)
+                else:
+                    self.controller.reset()
 
             self.previous_time = current_time
             rate.sleep()


### PR DESCRIPTION
I think the problem due to the carla's ROS signal initial time is different from the simulator, so when the self.dbw_enabled get something and running self.publish function, but the self.twist_cmd or self.current_velocity are still in None state. 

I have changed the code to call self.publish function after checking all the required signal.